### PR TITLE
Fix next/prev button on search pages

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/emf_TODO.txt
+++ b/lmfdb/modular_forms/elliptic_modular_forms/emf_TODO.txt
@@ -4,7 +4,6 @@ CRITICAL (BUGS):
 * data: Need to create mf_gamma1_subspaces table (Drew)
 * data: populate embeddings column by computing roots of defining polynomials and matching with complex data (Edgar)
 * data: Add isogeny_class_label to L-functions so that we can include friend links to elliptic curves (Edgar)
-* search results: next button not working (David, David L-D)
 
 IMPORTANT:
 * form pages: pictures from q-expansion (Drew, John Cremona)

--- a/lmfdb/modular_forms/elliptic_modular_forms/templates/emf_refine_search.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/templates/emf_refine_search.html
@@ -73,7 +73,7 @@
 
 
 <tr style="height:50px">
-<td class="button"><button type='submit' name='submit' value='{{info.submit}}' style="width: 110px">Search again</button></td>
+<td class="button"><button type='submit' name='submit_again' value='{{info.submit}}' style="width: 110px">Search again</button></td>
 </tr>
 
 </table>


### PR DESCRIPTION
For what it's worth, the problem is that there was another element on the page whose name was "submit". In modern jquery, this is a reserved name and takes some precedence (or something like that --- I don't really know what I'm talking about). Changing the name to something else seems to have no bad effects, and it makes the search work fine.