### PR TITLE
Dirichlet character improvements

### DIFF
--- a/lmfdb/WebCharacter.py
+++ b/lmfdb/WebCharacter.py
@@ -784,32 +784,31 @@ class WebDBDirichletCharacter(WebChar, WebDirichlet):
         self.codelangs = ('pari', 'sage')
         self._populate_from_db()
 
-################TODO DLD
     @property
-    def previous(self):   return None
-    @property
-    def next(self):       return None
-
-
-    @property
-    def genvalues(self):  return None
-    def value(self, *args): return None
-
-    def charisprimitive(self, mod, num):
+    def previous(self):
         return None
 
+    @property
+    def next(self):
+        return None
+
+#######################
+# The parts responsible for allowing computation of Gauss sums, etc. on page
     @property
     def charsums(self, *args):
         return False
 
+    def gauss_sum(self, *args):
+        return None
 
-    def gauss_sum(self, *args): return None
-    def jacobi_sum(self, *args): return None
-    def kloosterman_sum(self, *args): return None
+    def jacobi_sum(self, *args):
+        return None
 
+    def kloosterman_sum(self, *args):
+        return None
 
-    ### AND ALL THE CODE PIECES
-
+    def value(self, *args):
+        return None
 ########################
 
     @property

--- a/lmfdb/WebCharacter.py
+++ b/lmfdb/WebCharacter.py
@@ -846,7 +846,7 @@ class WebDBDirichlet(WebDirichlet):
         elif numer == 3 and denom == 4:
             ret = '-i'
         else:
-            ret = r"e\left(\frac{}{}\right)".format(numer, denom)
+            ret = r"e\left(\frac{%s}{%s}\right)" % (numer, denom)
         if texify:
             return "\({}\)".format(ret)
         else:
@@ -1160,6 +1160,7 @@ class WebSmallDirichletCharacter(WebChar, WebDirichlet):
 
     @property
     def orbit_label(self):
+        logger.warning("Orbit label code was called. This shouldn't happen.")
         if self.modulus > 10000:
             return
         # Shortcut the trivial character, which behaves differently

--- a/lmfdb/WebCharacter.py
+++ b/lmfdb/WebCharacter.py
@@ -166,7 +166,11 @@ class WebDirichlet(WebCharObject):
             num = c
             if prim == None:
                 prim = self.charisprimitive(mod,num)
-        return ( mod, num, self.char2tex(mod,num), prim)
+        else:
+            num = c
+            if prim == None:
+                prim = self.charisprimitive(mod, num)
+        return (mod, num, self.char2tex(mod,num), prim)
 
     def charisprimitive(self,mod,num):
         if isinstance(self.H, DirichletGroup_conrey) and self.H.modulus()==mod:
@@ -890,11 +894,11 @@ class WebDBDirichlet(WebDirichlet):
             self.parity = 'Even'
 
     def _set_galoisorbit(self, orbit_data):
+        if self.modulus == 1:
+            self.galoisorbit = [self._char_desc(1, mod=1,prim=True)]
+            return
         upper_limit = min(200, self.order + 1)
-        orbit = (
-            power_mod(self.number, k, self.modulus)
-            for k in xsrange(1, upper_limit) if gcd(k, self.order) == 1
-        )
+        orbit = orbit_data['galois_orbit'][:upper_limit]
         self.galoisorbit = list(
             self._char_desc(num, prim=self.isprimitive) for num in orbit
         )
@@ -1014,6 +1018,7 @@ class WebDBDirichletCharacter(WebChar, WebDBDirichlet):
         self.maxcols = 30
         self.coltruncate = False
         WebDBDirichlet.__init__(self, **kwargs)
+        logger.warning("Now: {}  {}".format(self.modulus, self.number))
 
     @property
     def texname(self):

--- a/lmfdb/characters/ListCharacters.py
+++ b/lmfdb/characters/ListCharacters.py
@@ -133,9 +133,18 @@ def get_character_order(a, b, limit=7):
         return l
     return [(_, line(_)) for _ in range(a, b)]
 
+# DLD add information here
 def charinfo(chi):
     """ return data associated to the WebDirichletCharacter chi """
-    return (chi.modulus(), chi.number(), chi.conductor(), chi.multiplicative_order(), chi.is_odd(), chi.is_primitive(), WebDirichlet.char2tex(chi.modulus(), chi.number()))
+    return (
+        chi.modulus(),
+        chi.number(),
+        chi.conductor(),
+        chi.multiplicative_order(),
+        chi.is_odd(),
+        chi.is_primitive(),
+        WebDirichlet.char2tex(chi.modulus(), chi.number()),
+    )
 
 class CharacterSearch:
 
@@ -159,7 +168,7 @@ class CharacterSearch:
         if self.order and self.mmin > 999:
             flash(Markup("Error: For order searching the minimum modulus needs to be less than $10^3$"),"error")
             raise ValueError('modulus')
-        
+
         self.cmin, self.cmax = parse_interval(self.conductor, 'conductor') if self.conductor else (1, self.mmax)
         self.omin, self.omax = parse_interval(self.order, 'order') if self.order else (1, self.cmax)
         self.cmax = min(self.cmax,self.mmax)
@@ -184,7 +193,7 @@ class CharacterSearch:
 
         self.start = int(query.get('start', '0'))
 
-        
+
     def results(self):
         info = {}
         L, complete = self.results_by_modulus(self.mmin, self.mmax, self.start, self.limit)
@@ -202,7 +211,7 @@ class CharacterSearch:
         return info
 
     def list_valid(self):
-        return 
+        return
 
     def results_by_modulus(self, mmin, mmax, start, limit):
         res = []
@@ -225,6 +234,7 @@ class CharacterSearch:
                 continue
             if self.order and not divisors_in_interval(modn_exponent(q), self.omin, self.omax):
                 continue
+            # DLD add logic if q < 10000 here
             G = DirichletGroup_conrey(q)
             for chi in G:
                 ticks += 1
@@ -244,6 +254,6 @@ class CharacterSearch:
                 flash(Markup("Error: Unable to complete query within timeout (showing results up to modulus %d).  Try narrowing your search."%q),"error")
                 return res, False
         return res, True
-                
-                
+
+
 

--- a/lmfdb/characters/ListCharacters.py
+++ b/lmfdb/characters/ListCharacters.py
@@ -313,7 +313,7 @@ class CharacterSearch:
                 continue
             if q < 10000:
                 # Generate admissible numbers for Conrey labels
-                for num in (v for v in range(1, q) if gcd(v, q) == 1):
+                for num in (v for v in range(1, q+1) if gcd(v, q) == 1):
                     ticks += 1
 
                     if ticks > 100000:

--- a/lmfdb/characters/TinyConrey.py
+++ b/lmfdb/characters/TinyConrey.py
@@ -1,18 +1,31 @@
 from sage.all import gcd, Mod, Integer
 from sage.misc.cachefunc import cached_method
 
+
 def symbol_numerator(cond, parity):
-    #Reference: Sect. 9.3, Montgomery, Hugh L; Vaughan, Robert C. (2007). Multiplicative number theory. I. Classical theory. Cambridge Studies in Advanced Mathematics 97 
-    # Let F = Q(\sqrt(d)) with d a non zero squarefree integer then a real Dirichlet character \chi(n) can be represented as a Kronecker symbol (m / n) where { m  = d if # d = 1 mod 4 else m = 4d if d = 2,3 (mod) 4 }  and m is the discriminant of F. The conductor of \chi is |m|. 
-    # symbol_numerator returns the appropriate Kronecker symbol depending on the conductor of \chi. 
+    # Reference: Sect. 9.3, Montgomery, Hugh L; Vaughan, Robert C. (2007).
+    # Multiplicative number theory. I. Classical theory. Cambridge Studies in
+    # Advanced Mathematics 97
+    #
+    # Let F = Q(\sqrt(d)) with d a non zero squarefree integer then a real
+    # Dirichlet character \chi(n) can be represented as a Kronecker symbol
+    # (m / n) where { m  = d if # d = 1 mod 4 else m = 4d if d = 2,3 (mod) 4 }
+    # and m is the discriminant of F. The conductor of \chi is |m|.
+    #
+    # symbol_numerator returns the appropriate Kronecker symbol depending on
+    # the conductor of \chi.
     m = cond
     if cond % 2 == 1:
         if cond % 4 == 3:
             m = -cond
     elif cond % 8 == 4:
-        # Fixed cond % 16 == 4 and cond % 16 == 12 were switched in the previous version of the code. 
-        # Let d be a non zero squarefree integer. If d  = 2,3 (mod) 4 and if cond = 4d = 4 ( 4n + 2) or 4 (4n + 3) = 16 n + 8 or 16n + 12 then we set m = cond. 
-        # On the other hand if d = 1 (mod) 4 and cond = 4d = 4 (4n +1) = 16n + 4 then we set m = -cond. 
+        # Fixed cond % 16 == 4 and cond % 16 == 12 were switched in the
+        # previous version of the code.
+        #
+        # Let d be a non zero squarefree integer. If d  = 2,3 (mod) 4 and if
+        # cond = 4d = 4 ( 4n + 2) or 4 (4n + 3) = 16 n + 8 or 16n + 12 then we
+        # set m = cond.  On the other hand if d = 1 (mod) 4 and cond = 4d = 4
+        # (4n +1) = 16n + 4 then we set m = -cond.
         if cond % 16 == 4:
             m = -cond
     elif cond % 16 == 8:
@@ -21,6 +34,7 @@ def symbol_numerator(cond, parity):
     else:
         return None
     return m
+
 
 def kronecker_symbol(m):
     if m:

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -196,6 +196,7 @@ def render_Dirichletwebpage(modulus=None, number=None):
     if number == None:
         if modulus < 10000:
             info = WebDBDirichletGroup(**args).to_dict()
+            info['show_orbit_label'] = True
         elif modulus < 100000:
             info = WebDirichletGroup(**args).to_dict()
         else:

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -6,10 +6,6 @@ import flask
 from flask import render_template, url_for, request, redirect
 from sage.all import gcd, randint
 from lmfdb.utils import to_dict, flash_error
-
-from lmfdb.utils import make_logger
-logger = make_logger("DLD")
-
 from lmfdb.characters.utils import url_character
 from lmfdb.WebCharacter import (
         WebDirichletGroup,

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -7,7 +7,7 @@ from flask import render_template, url_for, request, redirect
 from sage.all import gcd, randint
 from lmfdb.utils import to_dict, flash_error
 from lmfdb.characters.utils import url_character
-from lmfdb.WebCharacter import WebDirichletGroup, WebSmallDirichletGroup, WebDirichletCharacter, WebSmallDirichletCharacter
+from lmfdb.WebCharacter import WebDirichletGroup, WebSmallDirichletGroup, WebDirichletCharacter, WebSmallDirichletCharacter, WebDBDirichletCharacter
 from lmfdb.WebCharacter import WebHeckeExamples, WebHeckeFamily, WebHeckeGroup, WebHeckeCharacter
 from lmfdb.WebNumberField import WebNumberField
 from lmfdb.characters import characters_page
@@ -205,7 +205,10 @@ def render_Dirichletwebpage(modulus=None, number=None):
     if number <= 0 or gcd(modulus,number) != 1 or number > modulus:
         flash_error("the value %s is invalid.  It should be a positive integer coprime to and no greater than the modulus %s.", args['number'],args['modulus'])
         return redirect(url_for(".render_Dirichletwebpage"))
-    if modulus < 100000:
+    if modulus < 10000:
+        webchar = WebDBDirichletCharacter(**args)
+        info = webchar.to_dict()
+    elif modulus < 100000:
         webchar = WebDirichletCharacter(**args)
         info = webchar.to_dict()
     else:

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -6,8 +6,19 @@ import flask
 from flask import render_template, url_for, request, redirect
 from sage.all import gcd, randint
 from lmfdb.utils import to_dict, flash_error
+
+from lmfdb.utils import make_logger
+logger = make_logger("DLD")
+
 from lmfdb.characters.utils import url_character
-from lmfdb.WebCharacter import WebDirichletGroup, WebSmallDirichletGroup, WebDirichletCharacter, WebSmallDirichletCharacter, WebDBDirichletCharacter
+from lmfdb.WebCharacter import (
+        WebDirichletGroup,
+        WebSmallDirichletGroup,
+        WebDirichletCharacter,
+        WebSmallDirichletCharacter,
+        WebDBDirichletCharacter,
+        WebDBDirichletGroup
+)
 from lmfdb.WebCharacter import WebHeckeExamples, WebHeckeFamily, WebHeckeGroup, WebHeckeCharacter
 from lmfdb.WebNumberField import WebNumberField
 from lmfdb.characters import characters_page
@@ -183,7 +194,9 @@ def render_Dirichletwebpage(modulus=None, number=None):
 
 
     if number == None:
-        if modulus < 100000:
+        if modulus < 10000:
+            info = WebDBDirichletGroup(**args).to_dict()
+        elif modulus < 100000:
             info = WebDirichletGroup(**args).to_dict()
         else:
             info = WebSmallDirichletGroup(**args).to_dict()

--- a/lmfdb/characters/templates/CharGroup.html
+++ b/lmfdb/characters/templates/CharGroup.html
@@ -40,6 +40,15 @@
 {% if contents %}
 {# Characters #}
 <h2> {%if rowtruncate%}First {{contents|count}} of {{order}} {{KNOWL('character.dirichlet',title='characters')}}{% else %}{{KNOWL('character.dirichlet',title='Characters')}}{%endif%}</h2>
+<p>
+Each row describes a character. When available, the columns show the
+{% if show_orbit_label %}
+{{KNOWL('character.dirichlet.galois_orbit_label', title='orbit label')}},
+{% endif %}
+{{KNOWL('character.dirichlet.order', title='order')}} of the character,
+whether the character is {{KNOWL('character.dirichlet.primitive', title='primitive')}},
+and several values of the character.
+</p>
 <table class="ntdata" id="chitable">
   <thead class="space">
     <tr> 

--- a/lmfdb/characters/templates/Character.html
+++ b/lmfdb/characters/templates/Character.html
@@ -6,6 +6,7 @@
 {{ place_code('init') }}
 
 {# Kronecker symbol #}
+
 {% if symbol %}
   {% if isprimitive == "Yes" and indlabel %}
     <h2>
@@ -37,7 +38,7 @@
   <tr> <td colspan='3'> {{ place_code('parity') }} </td> </tr>
   <tr> <td> {{KNOWL('character.dirichlet.parity',title='Parity')}} </td> <td>=</td> <td> {{ parity }}</td> </tr>
   {% endif %}
-  <tr> <td> {{KNOWL('character.dirichlet.galois_orbit_label',title='Orbit label')}} </td> <td>=</td> <td> {{ modulus }}.{{ orbit_label}} </td> </tr>
+  <tr> <td> {{KNOWL('character.dirichlet.galois_orbit_label',title='Orbit label')}} </td> <td>=</td> <td> {{ modulus }}.{{ orbit_label }} </td> </tr>
 </table>
 
 {% if galoisorbit %}

--- a/lmfdb/characters/templates/character_search_results.html
+++ b/lmfdb/characters/templates/character_search_results.html
@@ -80,10 +80,10 @@ table td.params {
   <th align="center">{{ KNOWL('character.dirichlet.primitive', title='Primitive') }}</th>
 </tr>
 
-{% for (mod,num,cond,order,par,prim,name) in info.chars: %}
+{% for (mod, num, cond, orbit_label, order, par, prim, name) in info.chars: %}
 <tr>
 <td class="center"><a href="{{mod}}/{{num}}">{{name}}</a></td>
-<td class="center">In Progress</a></td>
+<td class="center">{{orbit_label}}</a></td>
 <td class="center">{{mod}}</td>
 <td class="center">{{cond}}</td>
 <td class="center">{{order}}</td>

--- a/lmfdb/characters/templates/character_search_results.html
+++ b/lmfdb/characters/templates/character_search_results.html
@@ -72,6 +72,7 @@ table td.params {
 <table>
 <tr>
   <th class="center">{{ KNOWL('character.dirichlet.conrey', title='Conrey label')}}</th>
+  <th class="center">{{ KNOWL('character.dirichlet.galois_orbit_label', title='Orbit label')}}</th>
   <th class="center">{{ KNOWL('character.dirichlet.modulus', title='Modulus')}}</th>
   <th class="center">{{ KNOWL('character.dirichlet.conductor', title='Conductor') }}</th>
   <th align="center">{{ KNOWL('character.dirichlet.order', title='Order') }}</th>
@@ -82,6 +83,7 @@ table td.params {
 {% for (mod,num,cond,order,par,prim,name) in info.chars: %}
 <tr>
 <td class="center"><a href="{{mod}}/{{num}}">{{name}}</a></td>
+<td class="center">In Progress</a></td>
 <td class="center">{{mod}}</td>
 <td class="center">{{cond}}</td>
 <td class="center">{{order}}</td>

--- a/lmfdb/characters/utils.py
+++ b/lmfdb/characters/utils.py
@@ -7,30 +7,30 @@ import re
 #############################################################################
 
 def evalpolelt(label,gen,genlabel='a'):
-    """ label is a compact polynomial expression in genlabel                    
-        ( '*' and '**' are removed )                                            
-    """                                                                         
-    res = 0                                                                     
-    regexp = r'([+-]?)([+-]?\d*o?\d*)(%s\d*)?'%genlabel                         
-    for m in re.finditer(regexp,label):                                         
-        s,c,e = m.groups()                                                      
-        if c == '' and e == None: break    
-        if c == '':          
-            c = 1                            
-        else:                                
+    """ label is a compact polynomial expression in genlabel
+        ( '*' and '**' are removed )
+    """
+    res = 0
+    regexp = r'([+-]?)([+-]?\d*o?\d*)(%s\d*)?'%genlabel
+    for m in re.finditer(regexp,label):
+        s,c,e = m.groups()
+        if c == '' and e == None: break
+        if c == '':
+            c = 1
+        else:
             """ c may be an int or a rational a/b """
             from sage.rings.rational import Rational
             c = str(c).replace('o','/')
-            c = Rational(c)                                                      
-        if s == '-': c = -c                                                     
-        if e == None:                                                           
-            e = 0                                                               
-        elif e == genlabel:                                                     
-            e = 1                                                               
+            c = Rational(c)
+        if s == '-': c = -c
+        if e == None:
+            e = 0
+        elif e == genlabel:
+            e = 1
         else:
-            e = int(e[1:])                                                                   
-        res += c*gen**e           
-    return res              
+            e = int(e[1:])
+        res += c*gen**e
+    return res
 
 def complex2str(g, digits=10):
     real = round(g.real(), digits)


### PR DESCRIPTION
This pull request does a number of things for Dirichlet characters.

For moduli up to 10000, character pages are now populated based on data from the database, and search results now use database data when available. Search results, character group pages, and character main pages show the orbit_label.

Since these pages no longer require on-the-fly computation, I removed the Gauss sum, Jacobi sum, and Kloosterman code from them. (I don't know if anyone has ever used them or cared to). I left the single value-at computation box, and it doesn't compute anything by default.

I could be easily convinced to either add back in the Gauss, Jacobi, and Kloosterman code, or to remove the value-at code --- these are both straightforward.