### PR TITLE
Fix Dirichlet character test

### DIFF
--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -24,15 +24,15 @@ class WebCharacterTest(LmfdbTest):
 
 class DirichletSearchTest(LmfdbTest):
 
-    def test_condbrowse(self): 
+    def test_condbrowse(self):
         W = self.tc.get('/Character/Dirichlet/?condbrowse=24-41')
         assert '(\\frac{40}{\\bullet}\\right)' in W.data
 
-    def test_order(self): 
+    def test_order(self):
         W = self.tc.get('/Character/Dirichlet/?order=19-23')
         assert '\chi_{25}(2' in W.data
 
-    def test_modbrowse(self): 
+    def test_modbrowse(self):
         W = self.tc.get('/Character/Dirichlet/?modbrowse=51-81')
         """
         curl -s '/Character/?modbrowse=51-81' | grep 'Dirichlet/[0-9][0-9]/27' | wc -l
@@ -55,7 +55,7 @@ class DirichletSearchTest(LmfdbTest):
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Even&limit=25')
         assert '\chi_{50}(11,' in W.data and '\chi_{75}(46,' in W.data
 
-    def test_condsearch(self): 
+    def test_condsearch(self):
         W = self.tc.get('/Character/Dirichlet/?conductor=111')
         assert '111/17' in W.data
 
@@ -146,7 +146,7 @@ class DirichletCharactersTest(LmfdbTest):
 
     def test_dirichletchar531(self):
         W = self.tc.get('/Character/Dirichlet/531/40')
-        assert '/Character/Dirichlet/531/391' in W.data
+        assert '/Character/Dirichlet/531/247' in W.data
         assert '(356,235)' in W.data, "generators"
         assert 'Kloosterman sum' in W.data
         assert  '(\\zeta_{87})' in W.data, "field of values"
@@ -165,7 +165,7 @@ class DirichletCharactersTest(LmfdbTest):
         assert '/SatoTateGroup/0.1.300' in W.data
         b = get_lfunction_by_url('Character/Dirichlet/9999/2')
         assert bool(b) == ('L/Character/Dirichlet/9999/2' in W.data)
-        
+
     def test_dirichletchar99999999999999999lfunc(self):
         """ Check Dirichlet character with very large modulus"""
         W = self.tc.get('/Character/Dirichlet/99999999999999999999/2')


### PR DESCRIPTION
The old test was for checking for another element in the Galois orbit,
but the Galois orbit computed wasn't ordered --- its order came from the
way in which it was computed on the fly. Now the Galois orbit presented
is ordered (from smallest Conrey index to highest), and so displaying
only the first several doesn't hit the same one.

Now I check for a different character in the Galois orbit.