### PR TITLE
multiple <- divisor

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform.html
@@ -192,7 +192,7 @@ function show_qexp(qstyle) {
     <p> The index of the coefficient ring in the {{ KNOWL('nf.ring_of_integers',title='maximal order') }} of the coefficient field is {{ newform.hecke_ring_index_factored }}. </p>
     {% endif %} {# newform.hecke_ring_index == 1 #}
   {% elif newform.hecke_ring_index > 1 %}
-    <p> The index of the coefficient ring in the {{ KNOWL('nf.ring_of_integers',title='maximal order') }} of the coefficient field is a multiple of {{ newform.hecke_ring_index_factored }}. </p>
+    <p> The index of the coefficient ring in the {{ KNOWL('nf.ring_of_integers',title='maximal order') }} of the coefficient field is a divisor of {{ newform.hecke_ring_index_factored }}. </p>
   {% endif %} {# newform.hecke_ring_index_proven #}
   {% endif %} {# newform.dim > 1 #}
 </div>

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -422,7 +422,7 @@ def lfuncEPhtml(L,fmt, prec = None):
         out = "1"
         for i,elt in enumerate(poly):
             if elt is None or (i == prec and prec != len(poly) - 1):
-                out += "O(%s)" % (seriesvar(i, "polynomial"),)
+                out += "+O(%s)" % (seriesvar(i, "polynomial"),)
                 break;
             elif i > 0:
                 out += seriescoeff(elt, i, "series", "polynomial", 3)


### PR DESCRIPTION
If you have an order contained in the maximal order, we can bound its index from above--so "multiple of" should be "divisor of".  

Also, it was displaying O(T^N) in the L-function Euler factors without a + in front.  

In both cases, I just did a spot check, so if you're knowledgeable about the code please check for repercussions elsewhere.
