### PR TITLE
Use character orbit label instead of Conrey label

### DIFF
--- a/lmfdb/classical_modular_forms/cmf_TODO.txt
+++ b/lmfdb/classical_modular_forms/cmf_TODO.txt
@@ -125,3 +125,4 @@ Some progress on:
 - L-functions and modularity #2032
 - Galois conjugate objects: Hilbert, Bianchi, EC #2262
 - Display the L-function factors #2269
+

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -230,7 +230,8 @@ class WebNewformSpace(object):
                 self.dim_str = r"\(%s + %s\)"%(self.plus_dim, self.minus_dim)
         else:
             self.trivial_character = False
-            character_str = r"Character \(\chi_{{{level}}}({conrey}, \cdot)\)".format(level=self.level, conrey=self.char_labels[0])
+            character_str = r"Character {level}.{orbit_label}".format(level=self.level, orbit_label=self.char_orbit_label)
+            # character_str = r"Character \(\chi_{{{level}}}({conrey}, \cdot)\)".format(level=self.level, conrey=self.char_labels[0])
             self.dim_str = r"\(%s\)"%(self.dim)
         self.title = r"Space of Cuspidal Newforms of Weight %s, Level %s and %s"%(self.weight, self.level, character_str)
         self.friends = []


### PR DESCRIPTION
On spaces, we used to display "Space of Cuspidal Newforms of Weight 2, Level 227 and Character \chi_{227}(3, \cdot)", but that's not how we're thinking about it: we haven't embedded the space in the complex numbers, and actually everything we show on the page is Galois invariant.  So I think we should use the character orbit label