### PR TITLE
Nonesubs

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1309,12 +1309,20 @@ def render_abstract_subgroup(label):
     info["create_boolean_string"] = create_boolean_string
     info["create_boolean_subgroup_string"] = create_boolean_subgroup_string
     info["pos_int_and_factor"] = pos_int_and_factor
-    
-    if seq.normal:
-        title = r"Normal subgroup $%s \trianglelefteq %s$"
+
+
+    if seq.subgroup_tex != "?":
+        if seq.normal:
+            title = r"Normal subgroup $%s \trianglelefteq %s$"
+        else:
+            title = r"Non-normal subgroup $%s \subseteq %s$"
+        title = title % (seq.subgroup_tex, seq.ambient_tex)
     else:
-        title = r"Non-normal subgroup $%s \subseteq %s$"
-    title = title % (seq.subgroup_tex, seq.ambient_tex)
+        if seq.normal:
+            title = r"Normal subgroup of $%s$"
+        else:
+            title = r"Non-normal subgroup of $%s$"
+        title = title % (seq.ambient_tex)
 
     properties = [
         ("Label", label),

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -234,25 +234,30 @@
   <table>
     <tr><td>{{KNOWL('group.permutation_degree', 'Permutation degree')}}:</td><td>{{gp.perm_degree()|safe}}</td></tr>
     <tr><td>{{KNOWL('group.transitive_degree', 'Transitive degree')}}:</td><td>{{gp.trans_degree()|safe}}</td></tr>
-  </table>
-</p>
-
-
-<p>
-  Minimum dimension of a faithful...
-  <table>
-    {% if gp.linC_degree != None %} <tr><td> ... {{KNOWL('group.linC_degree', 'complex matrix presentation')}}:</td><td>{{gp.linC_degree}}</td></tr> {% endif %}
-    {% if gp.irrC_degree == None %} <tr><td> ... {{KNOWL('group.irrC_degree','irreducible complex matrix presentation')}}:</td><td>not computed</td></tr> {% elif gp.irrC_degree == -1 %}
-    <tr><td> ... {{KNOWL('group.irrC_degree','irreducible complex matrix presentation')}}:</td><td>no faithful irreducible representations</td></tr>  {% else %}<tr><td> ... {{KNOWL('group.irrC_degree','irreducible complex matrix presentation')}}:</td><td>{{gp.irrC_degree}}</td></tr> {% endif %}
-     {% if gp.linQ_degree != None %} <tr><td> ... {{KNOWL('group.linQ_degree', 'rational matrix presentation')}}:</td><td>{{gp.linQ_degree}}</td></tr> {% endif %}
+    {% if gp.irrC_degree == None %} <tr><td>  {{KNOWL('group.irrC_degree','Minimal degree of $\mathbb{C}$-irrep')}}:</td><td>not computed</td></tr> {% elif gp.irrC_degree == -1 %}
+    <tr><td>  {{KNOWL('group.irrC_degree','Minimal degree of $\mathbb{C}$-irrep')}}:</td><td>no faithful irreducible representations</td></tr>  {% else %}<tr><td>  {{KNOWL('group.irrC_degree','Minimal degree of $\mathbb{C}$-irrep')}}:</td><td>{{gp.irrC_degree}}</td></tr> {% endif %}
     {% if gp.irrQ_degree == None %}
-<tr><td> ... {{KNOWL('group.irrQ_degree','irreducible rational matrix presentation')}}:</td><td>not computed</td></tr>
+<tr><td>  {{KNOWL('group.irrQ_degree','Minimal degree of $\mathbb{Q}$-irrep')}}:</td><td>not computed</td></tr>
     {% elif gp.irrQ_degree == -1 %}
-<tr><td> ... {{KNOWL('group.irrQ_degree','irreducible rational matrix presentation')}}:</td><td>no faithful irreducible rational representations</td></tr>
+<tr><td>  {{KNOWL('group.irrQ_degree','Minimal degree of $\mathbb{Q}$-irrep')}}:</td><td>no faithful irreducible rational representations</td></tr>
     {% else %}
+    <tr><td>  {{KNOWL('group.irrQ_degree','Minimal degree of $\mathbb{Q}$-irrep')}}:</td><td>{{gp.irrQ_degree}}</td></tr> {% endif %}
+  <tr>
+    <td>{{KNOWL('group.rank', 'Rank')}}:</td>
+    {% if gp.rank %}
+      <td>${{gp.rank}}$</td>
+    {% else %}
+      <td>not computed</td>
+    {% endif %}
+  </tr>
+  <tr>
+    <td>{{KNOWL('group.generators', 'Inequivalent ' + gp.gen_noun())}}:</td>
+  {% if gp.eulerian_function != None %}
+    <td>${{gp.eulerian_function}}$</td>
+    {% else %} <td>not computed</td> {% endif %}
 
-    <tr><td> ... {{KNOWL('group.irrQ_degree','irreducible rational matrix presentation')}}:</td><td>{{gp.irrQ_degree}}</td></tr> {% endif %}
-  </table>
+  </tr>
+</table>
 </p>
 
 
@@ -338,21 +343,6 @@
       {% endif %}
     </tr>
   {% endif %}
-  <tr>
-    <td>{{KNOWL('group.rank', 'Rank')}}:</td>
-    {% if gp.rank %}
-      <td>${{gp.rank}}$</td>
-    {% else %}
-      <td>not computed</td>
-    {% endif %}
-  </tr>
-  <tr>
-    <td>{{KNOWL('group.generators', 'Inequivalent ' + gp.gen_noun())}}:</td>
-  {% if gp.eulerian_function != None %}
-    <td>${{gp.eulerian_function}}$</td>
-    {% else %} <td>not computed</td> {% endif %}
-  
-  </tr>
 </table>
 
 {% else %}
@@ -433,6 +423,8 @@
     {% if gp.cent() %}
     <td><span class="subgp chargp" data-sgid="{{gp.cent()}}">$Z \simeq {{gp.cent_label()}}$</span></td>
     <td>{{gp.subgroups[gp.cent()].display_quotient("Z")|safe}}</td>
+    {% elif gp.center_label %}
+    <td>A subgroup isomorphic to <a href="{{url_for('.by_label', label=gp.center_label)}}">{{gp.center_label}}</td>
     {% else %}
     <td>not computed</td>
     {% endif %}
@@ -442,6 +434,8 @@
     {% if gp.comm() %}
     <td><span class="subgp chargp" data-sgid="{{gp.comm()}}">$G' \simeq {{gp.comm_label()}}$</span></td> {# match single quote for code highlighting purposes: ' #}
     <td>{{gp.subgroups[gp.comm()].display_quotient("G'", ab_invs=gp.smith_abelian_invariants)|safe}}</td>
+     {% elif gp.commutator_label %}
+    <td>A subgroup isomorphic to <a href="{{url_for('.by_label', label=gp.comutator_label)}}">{{gp.commutator_label}}</td>
     {% else %}
     <td>not computed</td>
     {% endif %}
@@ -451,6 +445,8 @@
     {% if gp.fratt() %}
     <td><span class="subgp chargp" data-sgid="{{gp.fratt()}}">$\Phi \simeq {{gp.fratt_label()}}$</span></td>
     <td>{{gp.subgroups[gp.fratt()].display_quotient("\\Phi")|safe}} </td>
+     {% elif gp.frattini_label %}
+    <td>A subgroup isomorphic to <a href="{{url_for('.by_label', label=gp.frattini_label)}}">{{gp.frattini_label}}</td>
     {% else %}
     <td> not computed</td>
     {% endif %}

--- a/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
@@ -143,9 +143,11 @@
     <tr><td>{{KNOWL('group.under_subgroup', 'Maximal under-subgroups:')}}</td>{% for H in seq.contains_ %}<td><a href="{{url_for('.by_subgroup_label', label=H.label)}}">${{H.subgroup_tex}}$</a></td>{% endfor %}</tr>
     {% endif %}
     {% if not seq.outer_equivalence %}
-      {% set others = seq.autjugate_subgroups() %}
-      {% if others %}
-        <tr><td>{{KNOWL('group.autjugate_subgroup', 'Autjugate subgroups')}}</td>{% for H in others %}<td><a href="{{url_for('.by_subgroup_label', label=H.label)}}">{{H.label}}</a></td>{% endfor %}</tr>
+    {% set others = seq.autjugate_subgroups() %}
+    {% if others == None %}
+     <tr><td>{{KNOWL('group.autjugate_subgroup', 'Autjugate subgroups')}}:</td> <td>Subgroups are not computed up to autjugacy.</td></tr>
+      {% elif others %}
+    <tr><td>{{KNOWL('group.autjugate_subgroup', 'Autjugate subgroups')}}:</td>{% for H in others %}<td><a href="{{url_for('.by_subgroup_label', label=H.label)}}">{{H.label}}</a></td>{% endfor %}</tr>
       {% endif %}
     {% endif %}
   </table>

--- a/lmfdb/groups/abstract/templates/auto_gens_page.html
+++ b/lmfdb/groups/abstract/templates/auto_gens_page.html
@@ -6,7 +6,9 @@
 <br>
 
 <p>
-&nbsp; Each row represents an {{KNOWL('group.automorphism', 'automorphism')}} given by it image on a set of {{KNOWL('group.generators','generators')}} of the group (represented by the columns).
+  &nbsp; Each row represents an {{KNOWL('group.automorphism', 'automorphism')}} given by it image on a set of {{KNOWL('group.generators','generators')}} of the group (listed as the headers of the columns). <br>
+
+  {% if gp.element_repr_type == 'PC' %} &nbsp; The entries in the table are given as words on the generators in the presentation for this group.   {% endif %}
 </p>
 
 
@@ -14,14 +16,13 @@
 <p>
   <table class="ntdata" style="margin-left:0;">
     <thead>
-      <tr> <th> generators of the group:</th>
-        {% for c in gp.auto_gens_list()[0] %}
+      <tr> <th> </th>         {% for c in gp.auto_gens_list()[0] %}
         <th>${{c}}$</th>
         {% endfor %}
       </tr>
       <tbody>
 	{% for i in range(1,gp.auto_gens_list()|length) %}
-      <tr><td> </td>
+      <tr> <td>  </td>
 	{% for j in gp.auto_gens_list()[i] %}
       <td>${{j}}$ </td>
       {% endfor %}

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -785,6 +785,8 @@ class WebAbstractGroup(WebObj):
             if cent_order_factored:
                 props.extend([(r"$\card{Z(G)}$",
                     web_latex(cent_order_factored) if cent_order_factored else nc)])
+            elif self.center_label:
+                 props.extend([(r"$\card{Z(G)}$", self.center_label.split(".")[0])])                
             else:
                 props.extend([(r"$\card{Z(G)}$", "not computed")])
 
@@ -2416,12 +2418,16 @@ class WebAbstractSubgroup(WebObj):
                 labels.extend([make_full(label) for label in llist])
         return list(db.gps_subgroups_test.search({"label": {"$in": labels}}))
 
+    
     def autjugate_subgroups(self):
-        return [
+        if self.amb.outer_equivalence == False and self.amb.complements_known == False and self.amb.subgroup_inclusions_known == False:
+            return None  #trying to say subgroups not computed up to autjugacy
+        else:
+            return [
             H
             for H in self.amb.subgroups.values()
             if H.aut_label == self.aut_label and H.label != self.label
-        ]
+            ]
 
     @lazy_attribute
     def centralizer_(self):


### PR DESCRIPTION
cleaned up generators of automorphisms (check PC language) 
updated C-irrep and Q-irrep degree and moved rank and inequiv gen tuples to new section
Fixed issue where all subgroups are listed as autjugate subgroups when subgroups weren't computed up to autjugacy.  (CHECK LANGUAGE: Subgroups are not computed up to autjugacy.)
Got rid of few cases where ? showed up in title of Normal subgroups when subgroup_tex was unknown for subgroup.  See [167772160.bng.40960.CP](https://groups.lmfdb.xyz/Groups/Abstract/sub/167772160.bng.40960.CP).
Updated so property box shows #center
Updated so center, commutator, and Frattini give abstract group if that as been computed (but not connected to specific subgroup. See language in: 2359296.cs  ALSO NOT LATEX!!!