### PR TITLE
Error on unknown search criteria; support pasting a full LMFDB url

### DIFF
--- a/CommandLineSearch.md
+++ b/CommandLineSearch.md
@@ -98,12 +98,19 @@ Pasting a full LMFDB url
 ------------------------
 
 Instead of giving the section and query separately, you can paste a full LMFDB
-search-results url (from either the production site `www.lmfdb.org` or the beta
-site `beta.lmfdb.org`) as the only argument.  It is split into the section and
+search-results url as the only argument, and it is split into the section and
 the search terms:
 
 ```bash
 ./lmfdb_search "https://www.lmfdb.org/NumberField/?degree=4&class_number=2"
+```
+
+Both the public site (`*.lmfdb.org`, e.g. `www.lmfdb.org` or `beta.lmfdb.org`)
+and the internal servers (`*.lmfdb.xyz`) are accepted, and the `https://` (or
+`http://`) prefix may be omitted:
+
+```bash
+./lmfdb_search "www.lmfdb.org/NumberField/?degree=4"
 ```
 
 If the url is a download url (it contains `download=1`/`Submit=...`, as produced

--- a/CommandLineSearch.md
+++ b/CommandLineSearch.md
@@ -90,10 +90,36 @@ parser for it); use a JSON query instead.
 
 The query may also be read from a file with `-i/--input`.
 
+Unknown search criteria are rejected rather than silently ignored: an
+unrecognized url parameter (e.g. a typo such as `degere=4`) or a json key that
+is not a column produces an error.
+
+Pasting a full LMFDB url
+------------------------
+
+Instead of giving the section and query separately, you can paste a full LMFDB
+search-results url (from either the production site `www.lmfdb.org` or the beta
+site `beta.lmfdb.org`) as the only argument.  It is split into the section and
+the search terms:
+
+```bash
+./lmfdb_search "https://www.lmfdb.org/NumberField/?degree=4&class_number=2"
+```
+
+If the url is a download url (it contains `download=1`/`Submit=...`, as produced
+by the **Download** button on a search-results page), the download language is
+used as the output format — so the url's "Pari/GP" download becomes `--format
+pari`, "SageMath" becomes `--format sage`, and so on.  An explicit `--format` on
+the command line overrides the format from the url.
+
+Only search-results urls are supported.  Object home pages (e.g.
+`.../NumberField/4.0.117.1`) and non-LMFDB hosts are rejected.
+
 Output formats
 --------------
 
-Select the format with `-t/--format` (default `raw`):
+Select the format with `-t/--format` (default `raw`, or the download format
+from a pasted url):
 
 | Format | Raw table | Section |
 | --- | --- | --- |
@@ -142,6 +168,12 @@ The same search directly against the raw table, as JSON, selecting two columns:
 
 ```bash
 ./lmfdb_search nf_fields '{"degree":4}' --cols label,degree --format json
+```
+
+A full search-results url pasted from the website (here a "SageMath" download):
+
+```bash
+./lmfdb_search "https://www.lmfdb.org/NumberField/?degree=4&download=1&Submit=sage"
 ```
 
 The five degree-4 fields of largest absolute discriminant (descending sort):

--- a/lmfdb/cmdline_search.py
+++ b/lmfdb/cmdline_search.py
@@ -77,24 +77,32 @@ def section_param_names(search_array):
     return names
 
 
-def check_query_columns(query, valid, parser):
-    """Raise a parser error if a dict query uses a key that is not a column.
+def bad_query_columns(query, valid):
+    """The keys of a dict query that are not columns (i.e. not in ``valid``).
 
-    Recurses into the lists of the ``$and``/``$or``/``$nor`` logical operators;
-    other ``$``-prefixed keys are psycodict value-operators and are left alone.
+    Recurses through the ``$and``/``$or``/``$not`` logical operators (mirroring
+    psycodict's own ``_columns_searched``); other ``$``-prefixed keys are
+    value-operators and are left alone.  A ``col.subkey`` key (jsonb access) is
+    checked against ``col``.
     """
+    if isinstance(query, list):  # the value of $and/$or, or a recursive $or
+        return [bad for part in query for bad in bad_query_columns(part, valid)]
     if not isinstance(query, dict):
-        return
+        return []
     bad = []
     for key, val in query.items():
-        if key in ("$and", "$or", "$nor"):
-            if isinstance(val, list):
-                for sub in val:
-                    check_query_columns(sub, valid, parser)
+        if key in ("$and", "$or", "$not"):
+            bad.extend(bad_query_columns(val, valid))
         elif key.startswith("$"):
             continue
-        elif key not in valid:
+        elif key.split(".")[0] not in valid:
             bad.append(key)
+    return bad
+
+
+def check_query_columns(query, valid, parser):
+    """Raise a parser error listing every key in a dict query that is not a column."""
+    bad = list(dict.fromkeys(bad_query_columns(query, valid)))
     if bad:
         parser.error("not a column of the search table: " + ", ".join(bad))
 

--- a/lmfdb/cmdline_search.py
+++ b/lmfdb/cmdline_search.py
@@ -37,6 +37,10 @@ DOWNLOAD_LANG = {"pari": "gp"}
 # website's "Submit" value uses "gp" where the CLI uses "pari").
 URL_FORMAT = {v: k for k, v in DOWNLOAD_LANG.items()}
 
+# Domains recognized when a full LMFDB url is pasted: the public site
+# (*.lmfdb.org) and the internal servers (*.lmfdb.xyz).
+LMFDB_DOMAINS = ("lmfdb.org", "lmfdb.xyz")
+
 # The LMFDB sections understood by section_lookup, as they appear in an LMFDB
 # url path.  Kept in sync with section_lookup by a test.
 SECTIONS = (
@@ -107,17 +111,36 @@ def check_query_columns(query, valid, parser):
         parser.error("not a column of the search table: " + ", ".join(bad))
 
 
+def is_lmfdb_host(netloc):
+    """Whether ``netloc`` (the host part of a url) is an LMFDB server."""
+    host = netloc.split("@")[-1].split(":")[0].lower()
+    return any(host == domain or host.endswith("." + domain) for domain in LMFDB_DOMAINS)
+
+
+def looks_like_lmfdb_url(arg):
+    """Whether a positional argument should be treated as a pasted LMFDB url
+    rather than a section/table name.  Accepts an explicit http(s) url or a
+    scheme-less url whose host is an LMFDB server (e.g. www.lmfdb.org/...)."""
+    if arg.startswith(("http://", "https://")):
+        return True
+    return is_lmfdb_host(arg.split("/", 1)[0].split("?", 1)[0])
+
+
 def parse_lmfdb_url(url, parser):
     """Split a full LMFDB search-results url into ``(section, query_string,
     download_format)``.
 
+    The url may omit the scheme (e.g. ``www.lmfdb.org/NumberField/?degree=4``).
     ``download_format`` is a CLI format name if the url triggers a download
     (``download=1``/``Submit=...``), otherwise ``None``.  Errors out on urls
     that are not LMFDB search-results urls.
     """
     parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https") or not (
-            parsed.netloc == "lmfdb.org" or parsed.netloc.endswith(".lmfdb.org")):
+    if not parsed.scheme:
+        # scheme-less url such as www.lmfdb.org/NumberField/?degree=4: urlparse
+        # puts the host in the path, so reparse with a scheme added.
+        parsed = urlparse("https://" + url)
+    if parsed.scheme not in ("http", "https") or not is_lmfdb_host(parsed.netloc):
         parser.error(f"not an LMFDB url: {url}")
     path = parsed.path.strip("/")
     # Sections may end in a slash in the url (e.g. Character/Dirichlet/).
@@ -324,7 +347,7 @@ def run(args, parser):
 
     # A full LMFDB search-results url can be pasted as the only argument; split
     # it into the section, the search terms and (if present) a download format.
-    if args.table.startswith(("http://", "https://")):
+    if looks_like_lmfdb_url(args.table):
         if args.query:
             parser.error("when pasting a full LMFDB url, do not also provide a separate query")
         if args.input is not None:

--- a/lmfdb/cmdline_search.py
+++ b/lmfdb/cmdline_search.py
@@ -20,7 +20,7 @@ import sys
 import csv
 import json
 from argparse import ArgumentParser
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse
 
 from lmfdb import db
 from lmfdb.utils.completeness import results_complete
@@ -33,9 +33,108 @@ LANGUAGE_FORMATS = ["text", "sage", "gap", "pari", "magma", "oscar"]
 # The LMFDB download machinery uses ``gp`` for the pari/gp language.
 DOWNLOAD_LANG = {"pari": "gp"}
 
+# Reverse map, used when reading a download language out of a pasted url (the
+# website's "Submit" value uses "gp" where the CLI uses "pari").
+URL_FORMAT = {v: k for k, v in DOWNLOAD_LANG.items()}
+
+# The LMFDB sections understood by section_lookup, as they appear in an LMFDB
+# url path.  Kept in sync with section_lookup by a test.
+SECTIONS = (
+    "L", "L/rational",
+    "ModularForm/GL2/Q/holomorphic", "ModularForm/GL2/Q/Maass",
+    "ModularForm/GL2/TotallyReal", "ModularForm/GL2/ImaginaryQuadratic",
+    "EllipticCurve/Q", "EllipticCurve", "Genus2Curve/Q", "ModularCurve/Q",
+    "HigherGenus/C/Aut", "Variety/Abelian/Fq", "Belyi", "NumberField",
+    "padicField", "Character/Dirichlet/", "ArtinRepresentation",
+    "Motive/Hypergeometric/Q", "GaloisGroup", "SatoTateGroup",
+    "Groups/Abstract", "Lattice",
+)
+
+# url query-string keys that are not search-form fields but commonly appear in a
+# search-results url (pagination, sorting, column control, download triggers).
+META_PARAMS = frozenset({
+    "search_type", "hst", "start", "count", "sort_order", "sort_dir",
+    "columns", "showcol", "hidecol", "search_array", "jump", "label", "labels",
+    "download", "Submit", "query", "download_row_count", "result_count",
+})
+
 
 def download_lang_key(fmt):
     return DOWNLOAD_LANG.get(fmt, fmt)
+
+
+def section_param_names(search_array):
+    """The set of url query-string keys recognized for a section: the names of
+    the search-form input boxes, plus the common meta parameters."""
+    names = set(META_PARAMS)
+    for arr in (getattr(search_array, "refine_array", None) or [],
+                getattr(search_array, "browse_array", None) or []):
+        for row in arr:
+            for box in row:
+                name = getattr(box, "name", None)
+                if name:
+                    names.add(name)
+    return names
+
+
+def check_query_columns(query, valid, parser):
+    """Raise a parser error if a dict query uses a key that is not a column.
+
+    Recurses into the lists of the ``$and``/``$or``/``$nor`` logical operators;
+    other ``$``-prefixed keys are psycodict value-operators and are left alone.
+    """
+    if not isinstance(query, dict):
+        return
+    bad = []
+    for key, val in query.items():
+        if key in ("$and", "$or", "$nor"):
+            if isinstance(val, list):
+                for sub in val:
+                    check_query_columns(sub, valid, parser)
+        elif key.startswith("$"):
+            continue
+        elif key not in valid:
+            bad.append(key)
+    if bad:
+        parser.error("not a column of the search table: " + ", ".join(bad))
+
+
+def parse_lmfdb_url(url, parser):
+    """Split a full LMFDB search-results url into ``(section, query_string,
+    download_format)``.
+
+    ``download_format`` is a CLI format name if the url triggers a download
+    (``download=1``/``Submit=...``), otherwise ``None``.  Errors out on urls
+    that are not LMFDB search-results urls.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not (
+            parsed.netloc == "lmfdb.org" or parsed.netloc.endswith(".lmfdb.org")):
+        parser.error(f"not an LMFDB url: {url}")
+    path = parsed.path.strip("/")
+    # Sections may end in a slash in the url (e.g. Character/Dirichlet/).
+    if path in SECTIONS:
+        section = path
+    elif path + "/" in SECTIONS:
+        section = path + "/"
+    else:
+        parser.error(f"{url} is not an LMFDB search-results url (could not identify a search section)")
+    fmt = None
+    is_download = False
+    kept = []
+    for key, val in parse_qsl(parsed.query, keep_blank_values=True):
+        if key == "Submit":
+            is_download = True
+            fmt = URL_FORMAT.get(val, val)
+        elif key in ("download", "download_row_count", "query"):
+            # download triggers / duplicated query; not part of the search
+            is_download = is_download or key == "download"
+        else:
+            kept.append((key, val))
+    if is_download and fmt is None:
+        # download with no explicit language defaults to text (as on the website)
+        fmt = "text"
+    return section, urlencode(kept), fmt
 
 
 def build_parser():
@@ -43,18 +142,22 @@ def build_parser():
         prog="LMFDBSearch",
         description="""Command-line search interface for the L-functions and modular forms database (LMFDB)
 
-You can provide input in two formats:
+You can provide input in several formats:
 * A url string, matching the query-string part of an LMFDB url.  For example, searching for number fields with degree 4 would be done with degree=4, matching the LMFDB url https://www.lmfdb.org/NumberField/?degree=4.
 * A json dictionary such as {"degree":4}.
+
+You can also paste a full LMFDB search-results url (from the production or beta
+site) as the only argument, and it will be split into the section and search
+terms; a download format in the url (e.g. Submit=sage) sets the output format.
 """)
 
-    parser.add_argument("table", help="Which table or section of the lmfdb to search")
+    parser.add_argument("table", help="Which table or section of the lmfdb to search, or a full LMFDB search-results url")
     parser.add_argument("query", nargs="*", help="A query constraining which results are returned.  If not present, all results will be included")
     parser.add_argument("-i", "--input", help="Input file with search query", )
     parser.add_argument("-s", "--sql", action="store_true", help="Use SQL for input")
     parser.add_argument("-o", "--output", help="Output file for search results")
     parser.add_argument("-f", "--force", action="store_true", help="Overwrite output file even if it exists")
-    parser.add_argument("-t", "--format", help="Output format", choices=["raw", "text", "json", "csv", "tsv", "sage", "gap", "pari", "magma", "oscar"], default="raw")
+    parser.add_argument("-t", "--format", help="Output format (default: raw, or the download format from a pasted url)", choices=["raw", "text", "json", "csv", "tsv", "sage", "gap", "pari", "magma", "oscar"], default=None)
     parser.add_argument("-p", "--completeness", action="store_true", help="Whether to include completeness information at the begining of the output")
     parser.add_argument("-c", "--cols", help="Which columns to include in the output")
     parser.add_argument("-l", "--limit", type=int, help="The number of matching results to return (-1 for no limit)", default=50)
@@ -210,6 +313,22 @@ def run(args, parser):
         else:
             parser.error("Too many positional arguments")
         return
+
+    # A full LMFDB search-results url can be pasted as the only argument; split
+    # it into the section, the search terms and (if present) a download format.
+    if args.table.startswith(("http://", "https://")):
+        if args.query:
+            parser.error("when pasting a full LMFDB url, do not also provide a separate query")
+        if args.input is not None:
+            parser.error("when pasting a full LMFDB url, do not also use --input")
+        section, url_query, url_format = parse_lmfdb_url(args.table, parser)
+        args.table = section
+        args.query = [url_query] if url_query else []
+        if url_format is not None and args.format is None:
+            args.format = url_format
+    if args.format is None:
+        args.format = "raw"
+
     if len(args.query) > 1:
         parser.error("Too many positional arguments")
 
@@ -266,12 +385,21 @@ def run(args, parser):
             if args.debug:
                 raise
             parser.error(str(err))
+        # Catch typo'd column names up front rather than letting them through
+        # (psycodict would otherwise raise a less friendly error).
+        check_query_columns(query, set(table.search_cols) | {"id"}, parser)
     elif section_search:
         info = parse_qs(args.query[0])
         for key, val in info.items():
             if len(val) > 1:
                 parser.error(f"Multiple values found for {key} in query string")
             info[key] = val[0]
+        # Reject unrecognized search parameters rather than silently ignoring
+        # them (a common and confusing mistake).
+        valid = section_param_names(search_array)
+        unknown = [key for key in info if key not in valid]
+        if unknown:
+            parser.error("unknown search parameter(s): " + ", ".join(unknown))
         info["search_array"] = search_array
         try:
             result = wrapper.make_query(info)

--- a/lmfdb/cmdline_search.py
+++ b/lmfdb/cmdline_search.py
@@ -67,8 +67,8 @@ def section_param_names(search_array):
     """The set of url query-string keys recognized for a section: the names of
     the search-form input boxes, plus the common meta parameters."""
     names = set(META_PARAMS)
-    for arr in (getattr(search_array, "refine_array", None) or [],
-                getattr(search_array, "browse_array", None) or []):
+    for arr in (getattr(search_array, "refine_array", []),
+                getattr(search_array, "browse_array", [])):
         for row in arr:
             for box in row:
                 name = getattr(box, "name", None)

--- a/lmfdb/tests/test_cmdline_search.py
+++ b/lmfdb/tests/test_cmdline_search.py
@@ -1,12 +1,14 @@
 
+import inspect
 import io
 import json
 import os
+import re
 import tempfile
 from contextlib import redirect_stdout
 
 from lmfdb.tests import LmfdbTest
-from lmfdb.cmdline_search import main
+from lmfdb.cmdline_search import main, parse_lmfdb_url, build_parser, section_lookup, SECTIONS
 
 
 class CmdlineSearchTest(LmfdbTest):
@@ -297,3 +299,103 @@ class CmdlineSearchTest(LmfdbTest):
     def test_error_invalid_sort_column(self):
         with self.assertRaises(SystemExit):
             self.run_cmd(["nf_fields", '{"degree":4}', "--sort", "not_a_column", "--limit", "1"])
+
+    # ------------------------------------------------------------------
+    # rejecting unknown search criteria (review comment)
+    # ------------------------------------------------------------------
+
+    def test_unknown_section_param_errors(self):
+        # A typo'd/unknown url parameter is an error, not silently ignored
+        with self.assertRaises(SystemExit):
+            self.run_cmd(["NumberField", "degree=4&nonsense=5", "--limit", "1"])
+
+    def test_known_noncolumn_section_param_ok(self):
+        # signature is a valid search box, even though it is not a db column
+        out = self.run_cmd(["NumberField", "degree=4&signature=[0,2]", "--cols", "label", "--limit", "1"])
+        self.assertEqual(len(self.raw_rows(out)), 1)
+
+    def test_unknown_json_column_errors(self):
+        with self.assertRaises(SystemExit):
+            self.run_cmd(["nf_fields", '{"degre":4}', "--cols", "label", "--limit", "1"])
+
+    def test_unknown_json_column_nested_errors(self):
+        # also caught inside $or
+        with self.assertRaises(SystemExit):
+            self.run_cmd(["nf_fields", '{"$or":[{"degree":4},{"notacol":1}]}', "--cols", "label", "--limit", "1"])
+
+    def test_json_value_operator_ok(self):
+        # $-operators at the value level are not mistaken for columns
+        out = self.run_cmd(["nf_fields", '{"degree":{"$gte":4}}', "--cols", "label,degree", "--limit", "3"])
+        self.assertEqual(len(self.raw_rows(out)), 3)
+
+    # ------------------------------------------------------------------
+    # pasting a full LMFDB url
+    # ------------------------------------------------------------------
+
+    def test_url_paste_search(self):
+        out = self.run_cmd(["https://www.lmfdb.org/NumberField/?degree=4", "--cols", "label,degree", "--limit", "2"])
+        rows = self.raw_rows(out)
+        self.assertEqual(len(rows), 2)
+        for row in rows:
+            self.assertEqual(row.split("|")[1], "4")
+
+    def test_url_paste_beta(self):
+        out = self.run_cmd(["https://beta.lmfdb.org/NumberField/?degree=4", "--cols", "label", "--limit", "2"])
+        self.assertEqual(len(self.raw_rows(out)), 2)
+
+    def test_url_paste_download_format(self):
+        # Submit=sage in the url selects the sage download format
+        out = self.run_cmd(["https://www.lmfdb.org/NumberField/?degree=4&download=1&Submit=sage", "--limit", "2"])
+        self.assertIn("data", out)
+        self.assertIn("4.0.", out)
+
+    def test_url_paste_format_override(self):
+        # an explicit --format overrides the download format in the url
+        out = self.run_cmd(["https://www.lmfdb.org/NumberField/?degree=4&Submit=sage", "--format", "json", "--limit", "1"])
+        data = json.loads(out)
+        self.assertEqual(len(data), 1)
+
+    def test_url_paste_bad_host_errors(self):
+        with self.assertRaises(SystemExit):
+            self.run_cmd(["https://evil.example.com/NumberField/?degree=4"])
+
+    def test_url_paste_object_page_errors(self):
+        # an object home page is not a search-results url
+        with self.assertRaises(SystemExit):
+            self.run_cmd(["https://www.lmfdb.org/NumberField/4.0.117.1"])
+
+    def test_url_paste_with_extra_query_errors(self):
+        with self.assertRaises(SystemExit):
+            self.run_cmd(["https://www.lmfdb.org/NumberField/?degree=4", "degree=2"])
+
+    # parse_lmfdb_url unit tests (no database access)
+
+    def test_parse_url_basic(self):
+        parser = build_parser()
+        section, query, fmt = parse_lmfdb_url("https://www.lmfdb.org/NumberField/?degree=4&class_number=2", parser)
+        self.assertEqual(section, "NumberField")
+        self.assertEqual(query, "degree=4&class_number=2")
+        self.assertIsNone(fmt)
+
+    def test_parse_url_pari_mapping(self):
+        # the website "gp" download language maps to the CLI "pari" format
+        parser = build_parser()
+        _, _, fmt = parse_lmfdb_url("https://www.lmfdb.org/NumberField/?degree=4&download=1&Submit=gp", parser)
+        self.assertEqual(fmt, "pari")
+
+    def test_parse_url_download_default_text(self):
+        parser = build_parser()
+        _, _, fmt = parse_lmfdb_url("https://www.lmfdb.org/NumberField/?download=1", parser)
+        self.assertEqual(fmt, "text")
+
+    def test_parse_url_trailing_slash_section(self):
+        parser = build_parser()
+        section, query, fmt = parse_lmfdb_url("https://www.lmfdb.org/Character/Dirichlet/?modulus=7", parser)
+        self.assertEqual(section, "Character/Dirichlet/")
+        self.assertEqual(query, "modulus=7")
+
+    def test_sections_match_section_lookup(self):
+        # SECTIONS must stay in sync with the section_lookup dispatch
+        src = inspect.getsource(section_lookup)
+        found = set(re.findall(r'section == "([^"]+)"', src))
+        self.assertEqual(set(SECTIONS), found)

--- a/lmfdb/tests/test_cmdline_search.py
+++ b/lmfdb/tests/test_cmdline_search.py
@@ -9,7 +9,8 @@ from contextlib import redirect_stdout
 
 from lmfdb.tests import LmfdbTest
 from lmfdb.cmdline_search import (
-    main, parse_lmfdb_url, build_parser, section_lookup, SECTIONS, bad_query_columns,
+    main, parse_lmfdb_url, looks_like_lmfdb_url, build_parser, section_lookup,
+    SECTIONS, bad_query_columns,
 )
 
 
@@ -373,6 +374,11 @@ class CmdlineSearchTest(LmfdbTest):
         out = self.run_cmd(["https://beta.lmfdb.org/NumberField/?degree=4", "--cols", "label", "--limit", "2"])
         self.assertEqual(len(self.raw_rows(out)), 2)
 
+    def test_url_paste_schemeless(self):
+        # a url without the http(s):// prefix is accepted
+        out = self.run_cmd(["www.lmfdb.org/NumberField/?degree=4", "--cols", "label", "--limit", "2"])
+        self.assertEqual(len(self.raw_rows(out)), 2)
+
     def test_url_paste_download_format(self):
         # Submit=sage in the url selects the sage download format
         out = self.run_cmd(["https://www.lmfdb.org/NumberField/?degree=4&download=1&Submit=sage", "--limit", "2"])
@@ -423,6 +429,33 @@ class CmdlineSearchTest(LmfdbTest):
         section, query, fmt = parse_lmfdb_url("https://www.lmfdb.org/Character/Dirichlet/?modulus=7", parser)
         self.assertEqual(section, "Character/Dirichlet/")
         self.assertEqual(query, "modulus=7")
+
+    def test_parse_url_schemeless_hosts(self):
+        parser = build_parser()
+        for url in ("www.lmfdb.org/NumberField/?degree=4",
+                    "lmfdb.org/NumberField/?degree=4"):
+            section, query, fmt = parse_lmfdb_url(url, parser)
+            self.assertEqual((section, query), ("NumberField", "degree=4"))
+
+    def test_parse_url_lmfdb_xyz_host(self):
+        # internal *.lmfdb.xyz servers are accepted, with or without scheme
+        parser = build_parser()
+        for url in ("http://abc.lmfdb.xyz/EllipticCurve/Q/?conductor=11",
+                    "devmirror.lmfdb.xyz/EllipticCurve/Q/?conductor=11"):
+            section, query, fmt = parse_lmfdb_url(url, parser)
+            self.assertEqual((section, query), ("EllipticCurve/Q", "conductor=11"))
+
+    def test_looks_like_lmfdb_url(self):
+        for arg in ("https://www.lmfdb.org/NumberField/?degree=4",
+                    "www.lmfdb.org/NumberField/?degree=4",
+                    "lmfdb.org/NumberField/",
+                    "beta.lmfdb.org/NumberField/",
+                    "devmirror.lmfdb.xyz/NumberField/"):
+            self.assertTrue(looks_like_lmfdb_url(arg), arg)
+        # section and table names, and non-LMFDB hosts, are not urls
+        for arg in ("NumberField", "EllipticCurve/Q", "nf_fields", "help",
+                    "example.com/NumberField"):
+            self.assertFalse(looks_like_lmfdb_url(arg), arg)
 
     def test_sections_match_section_lookup(self):
         # SECTIONS must stay in sync with the section_lookup dispatch

--- a/lmfdb/tests/test_cmdline_search.py
+++ b/lmfdb/tests/test_cmdline_search.py
@@ -8,7 +8,9 @@ import tempfile
 from contextlib import redirect_stdout
 
 from lmfdb.tests import LmfdbTest
-from lmfdb.cmdline_search import main, parse_lmfdb_url, build_parser, section_lookup, SECTIONS
+from lmfdb.cmdline_search import (
+    main, parse_lmfdb_url, build_parser, section_lookup, SECTIONS, bad_query_columns,
+)
 
 
 class CmdlineSearchTest(LmfdbTest):
@@ -323,10 +325,38 @@ class CmdlineSearchTest(LmfdbTest):
         with self.assertRaises(SystemExit):
             self.run_cmd(["nf_fields", '{"$or":[{"degree":4},{"notacol":1}]}', "--cols", "label", "--limit", "1"])
 
+    def test_unknown_json_column_in_not_errors(self):
+        # also caught inside a top-level $not (psycodict uses $not, not $nor)
+        with self.assertRaises(SystemExit):
+            self.run_cmd(["nf_fields", '{"$not":{"notacol":1}}', "--cols", "label", "--limit", "1"])
+
+    def test_not_query_ok(self):
+        out = self.run_cmd(["nf_fields", '{"degree":4,"$not":{"class_number":1}}', "--cols", "label,class_number", "--limit", "2"])
+        self.assertEqual(len(self.raw_rows(out)), 2)
+
     def test_json_value_operator_ok(self):
         # $-operators at the value level are not mistaken for columns
         out = self.run_cmd(["nf_fields", '{"degree":{"$gte":4}}', "--cols", "label,degree", "--limit", "3"])
         self.assertEqual(len(self.raw_rows(out)), 3)
+
+    # bad_query_columns unit tests (no database access)
+
+    def test_bad_query_columns_collects_whole_query(self):
+        # bad keys are collected from every part of the query, not just the
+        # branch where the first one is found
+        valid = {"degree", "class_number"}
+        query = {"foo": 1, "$or": [{"degree": 4}, {"bar": 2}], "$not": {"baz": 3}}
+        self.assertEqual(set(bad_query_columns(query, valid)), {"foo", "bar", "baz"})
+
+    def test_bad_query_columns_ignores_value_operators(self):
+        valid = {"degree"}
+        # value-level $not/$lte are operators, not columns
+        self.assertEqual(bad_query_columns({"degree": {"$not": {"$lte": 5}}}, valid), [])
+
+    def test_bad_query_columns_jsonb_subkey(self):
+        valid = {"coeffs"}
+        self.assertEqual(bad_query_columns({"coeffs.0": 1}, valid), [])
+        self.assertEqual(bad_query_columns({"coffs.0": 1}, valid), ["coffs.0"])
 
     # ------------------------------------------------------------------
     # pasting a full LMFDB url


### PR DESCRIPTION
Targets the `cmdline` branch (the head of LMFDB#7044).

## Review comment: error on unknown search criteria

[The review](https://github.com/LMFDB/lmfdb/pull/7044#issuecomment-4760141843) asked that a non-existent column name in the search criteria raise an error rather than being silently ignored.

- **Section url queries** (`NumberField degree=4`): the parameter names are validated against the section's search form — the search-array box names plus the common meta parameters (`sort_order`, `count`, …).  A typo like `degere=4` is now an error.  These are *form-field* names, not columns, so genuinely useful non-column parameters such as `signature` or `discriminant` are still accepted.
- **JSON queries** (`'{"degree":4}'`): keys are validated against the table columns up front (recursing into `$and`/`$or`/`$nor`), giving a clean message instead of the raw psycodict traceback.  Value-level `$`-operators (e.g. `{"degree":{"$gte":4}}`) are not mistaken for columns.

## New feature: paste a full LMFDB url

You can paste a full search-results url as the only argument and it is split into the section and the search terms:

```bash
./lmfdb_search "https://www.lmfdb.org/NumberField/?degree=4&class_number=2"
```

- Accepts both the production (`www.lmfdb.org`) and beta (`beta.lmfdb.org`) hosts.
- If the url is a **download** url (`download=1`/`Submit=...`, as produced by the Download button), the download language becomes the output format (`gp` → `pari`, etc.).  An explicit `--format` overrides it.
- Rejects non-LMFDB hosts and non-search urls (object home pages such as `.../NumberField/4.0.117.1`).

To carry the url's download format, `--format` now defaults to `None` and is resolved to `raw` (or the url's format) in `run()`.

## Tests / docs

53 tests pass (17 new), covering the validation behavior, url parsing (incl. the `gp`→`pari` mapping, the beta host, the trailing-slash `Character/Dirichlet/` section, and error cases), plus a guard that `SECTIONS` stays in sync with `section_lookup`.  `CommandLineSearch.md` documents both changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)