### PR TITLE
Add exact formulas for c

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -25,6 +25,7 @@ from .transitive_group import (
     subfield_display, resolve_display, chartable,
     cclasses_display_knowl, character_table_display_knowl,
     group_alias_table, WebGaloisGroup, knowl_cache)
+
 from lmfdb.logger import logger
 
 # Test to see if this gap installation knows about transitive groups

--- a/lmfdb/galois_groups/mallec.yaml
+++ b/lmfdb/galois_groups/mallec.yaml
@@ -1,0 +1,7 @@
+2T1: \frac{1}{\zeta(2)}=\frac{6}{\pi^2}
+3T1: \frac{11\sqrt{3}}{36\pi} \prod_{p\equiv 1 \pmod 6} \left(1-\frac{2}{p(p+1)}\right)
+3T2: \frac{1}{3\zeta(3)}
+4T1: \frac{3}{\pi^2}\left(\left(1+\frac{\sqrt{2}}{24}\right) \prod_{p\equiv 1 \pmod 4} \left(1+\frac{2}{p^{3/2}+p^{1/2}}\right)-1\right)
+4T2: \frac{23}{960} \prod_p\left(\left(1+\frac{3}{p}\right)\left(1-\frac{1}{p}\right)^3\right)
+4T5: \frac{5}{24} \prod_p \left(1+\frac{1}{p^2}-\frac{1}{p^3}-\frac{1}{p^4}\right)
+5T5: \frac{13}{120} \prod_p \left(1+\frac{1}{p^2}-\frac{1}{p^4}-\frac{1}{p^5} \right)

--- a/lmfdb/galois_groups/templates/gg-malle.html
+++ b/lmfdb/galois_groups/templates/gg-malle.html
@@ -38,15 +38,15 @@
 
 <h2> {{ KNOWL('gg.malle', 'Asymptotic' if gp.malle_proven else 'Conjectured asymptotic') }} </h2>
 
-<p> The {% if not gp.malle_proven %}conjectured {% endif %}count of number fields with this Galois group, of discriminant up to $X$, is asymptotic to</p>
-<p>$c X^a \log(X)^{b-1}$</p>
+<p> The {% if not gp.malle_proven %}conjectured {% endif %}count of extensions of $\Q$ with Galois group {{gp.label}}, of absolute discriminant up to $X$, is asymptotic to</p>
+<div align="center">$\displaystyle c X^a \log(X)^{b-1}$</div>
 
 <table>
-  <tr><td>{{ KNOWL('gg.malle_a', "$a(G)$") }}</td><td> ${{ gp.malle_a }}$ </td></tr>
-  <tr><td>{{ KNOWL('gg.malle_b', "$b(G)$ (Malle)") }}</td><td> {{ gp.malle_b }} </td></tr>
-  <tr><td>{{ KNOWL('gg.wang_b', "$b(G)$ (Wang)") }}</td><td> {{ gp.malle_wang_b }} </td></tr>
-  <tr><td>{{ KNOWL('gg.turkelli_b', "$b(G)$ (Türkelli)") }}</td><td> {{ gp.malle_turkelli_b }} </td></tr>  
-  <tr><td>{{ KNOWL('gg.malle_c', "$c(G)$") }}</td><td> {{ gp.malle_c }} </td></tr>
+  <tr><td>{{ KNOWL('gg.malle_a', "$a$") }}</td><td> ${{ gp.malle_a }}$ </td></tr>
+  <tr><td>{{ KNOWL('gg.malle_b', "$b_M$ (Malle)") }}</td><td> {{ gp.malle_b }} </td></tr>
+  <tr><td>{{ KNOWL('gg.wang_b', "$b_W$ (Wang)") }}</td><td> {{ gp.malle_wang_b }} </td></tr>
+  <tr><td>{{ KNOWL('gg.turkelli_b', "$b_T$ (Türkelli)") }}</td><td> {{ gp.malle_turkelli_b }} </td></tr>  
+  <tr><td>{{ KNOWL('gg.malle_c', "$c$") }}</td><td> {{ gp.malle_c() }} </td></tr>
   {# Don't currently display d = LCM(order of minimal index elements) #}
 </table>
 

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -14,6 +14,9 @@ from lmfdb.groups.abstract.web_groups import WebAbstractGroup, abelian_gp_displa
 
 CC_LIMIT = 160
 
+_curdir = os.path.dirname(os.path.abspath(__file__))
+mallec_pretty = yaml.load(open(os.path.join(_curdir, "mallec.yaml")), Loader=yaml.FullLoader)
+
 def knowl_cache(galois_labels=None, results=None):
     """
     Returns a dictionary for use in abstract_group_display_knowl, group_display and
@@ -193,12 +196,8 @@ class WebGaloisGroup:
         a = self.malle_a
         # Should get updated to malle_wang_b
         b1 = self._data['malle_b'] - 1
-        c = self._data.get('malle_c')
-        if c is None:
-            c = "c"
-        else:
-            c = str(c)+r'...\cdot '
-        return fr"${c}\ X^{{{a}}} \log(X)^{{{b1}}}$"
+        c = self.malle_c(show_c_equals=True)
+        return fr"$c\ X^{{{a}}} \log(X)^{{{b1}}}$ where {c}"
 
     @lazy_attribute
     def malle_a(self):
@@ -219,9 +218,26 @@ class WebGaloisGroup:
     def malle_wang_b(self):
         return self._data.get("malle_wang_b", "not computed")
 
-    @lazy_attribute
-    def malle_c(self):
-        return self._data.get("malle_c", "not computed")
+    def malle_c(self, show_c_equals=False):
+        if self.label in mallec_pretty:
+            s = fr'{mallec_pretty[self.label]}\approx {self._data.get("malle_c")}$'
+            if show_c_equals:
+                return "$c="+s
+            else:
+                return "$"+s
+
+        c = self._data.get("malle_c", None)
+        if c:
+            s = f'{c}$'
+            if show_c_equals:
+                return r"$c\approx "+s
+            else:
+                return "$"+s
+        else:
+            if show_c_equals:
+                return "$c$ is not computed"
+            else:
+                return "not computed"
 
     @lazy_attribute
     def _malle_status(self):
@@ -483,7 +499,7 @@ class WebGaloisGroup:
 
     def make_code_snippets(self):
         # read in code.yaml from galois_groups directory:
-        _curdir = os.path.dirname(os.path.abspath(__file__))
+        #_curdir = os.path.dirname(os.path.abspath(__file__))
         self.code = yaml.load(open(os.path.join(_curdir, "code.yaml")), Loader=yaml.FullLoader)
 
         for prop in ['gg', 'auts']:


### PR DESCRIPTION
This gives the ability to display exact formulas for the c in Malle's conjecture.  I think some people would expect them, especially in say degrees 2 and 3.  Since we only know them in a relatively small number of cases, they are stored in a yaml file.  They appear on both the Galois group and Malle pages.

There is also some tweaking of wording since we are only really considering extensions of Q (extensions with base field a number field are also number fields and conjectures/results exist there too leading to possible confusion).

Adjusting the notation for the various "b" is meant to match b_W on the main page with what is on the Malle page, but still needs more work.