### PR TITLE
Malle updates

### DIFF
--- a/lmfdb/galois_groups/mallec.yaml
+++ b/lmfdb/galois_groups/mallec.yaml
@@ -5,3 +5,4 @@
 4T2: \frac{23}{960} \prod_p\left(\left(1+\frac{3}{p}\right)\left(1-\frac{1}{p}\right)^3\right)
 4T5: \frac{5}{24} \prod_p \left(1+\frac{1}{p^2}-\frac{1}{p^3}-\frac{1}{p^4}\right)
 5T5: \frac{13}{120} \prod_p \left(1+\frac{1}{p^2}-\frac{1}{p^4}-\frac{1}{p^5} \right)
+6T2: \left(\frac{4}{9}+\frac{1}{3^{8/3}}+\frac{2}{3^{10/3}}\right)(1-3^{-1})\prod_{p\neq 2} (1+p^{-1}+p^{-4/3})(1-p^{-1})

--- a/lmfdb/galois_groups/templates/gg-malle.html
+++ b/lmfdb/galois_groups/templates/gg-malle.html
@@ -36,6 +36,13 @@
   <tr><td>{{ KNOWL('gg.other_representations', 'Low degree siblings') }}</td><td> {{gp.otherrep_list(givebound=False) | safe}}</td></tr>
 </table>
 
+{% if gp.n() == 1 %}
+<p>
+    For any field $K$, there is a unique extension of $K$, namely $K$
+    itself, with this Galois group.
+</p>
+{% else %}
+
 <h2> {{ KNOWL('gg.malle', 'Asymptotic' if gp.malle_proven else 'Conjectured asymptotic') }} </h2>
 
 <p> The {% if not gp.malle_proven %}conjectured {% endif %}count of extensions of $\Q$ with Galois group {{gp.label}}, of absolute discriminant up to $X$, is asymptotic to</p>
@@ -94,6 +101,7 @@ Special methods for A_n and S_n
 
 {% endif %}
 
+{% endif %}
 {% endblock %}
 
 

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -77,11 +77,18 @@ table.reptable td, table.reptable th {
 
   <h2>{{ KNOWL('gg.nf_statistics', title='Number field statistics') }}</h2>
 
+{% if gp.n() == 1 %}
+<blockquote>
+For any field $K$, there is a unique extension, namely $K$ itself, which
+has this Galois group.
+</blockquote>
+{% else %}
   <table>
     <tr><td>{{KNOWL('gg.malle', 'Number field count')}}</td><td>{{ gp.malle_str }}</td></tr>
     <tr><td>{{KNOWL('gg.malle_status', 'Proven')}}</td><td>{{ gp.malle_status|safe }}</td></tr>
     <tr><td colspan="2"><a href="{{url_for('.malle', label=info.label)}}">more details</a></td></tr>
   </table>
+{% endif %}
 
   <h2>{{ KNOWL('gg.conjugacy_classes', title='Conjugacy classes') }}</h2>
 

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -193,6 +193,8 @@ class WebGaloisGroup:
 
     @lazy_attribute
     def malle_str(self):
+        if self.n() == 1:
+            return "$1$"
         a = self.malle_a
         # Should get updated to malle_wang_b
         b1 = self._data['malle_b'] - 1


### PR DESCRIPTION
The current pages were wrong for the trivial group (claiming asymptotic to a non-constant function).  That could be fixed, but trying to fit it into the asymptotic seems like a complicated way to say something wrong.  So, this gives a direct message in this case.

This also adds one more exact formula