### PR TITLE
Fix field_pretty with partial data and restore torsion growth field d…

### DIFF
--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -889,11 +889,9 @@ class WebEC():
 
         # find all base changes of this curve in the database, if any:
         nf_to_curve = {rec["field_label"]: rec["label"] for rec in db.ec_nfcurves.search({'base_change': {'$contains': [self.lmfdb_label]}}, ["field_label", "label"])}
-        if nf_to_curve:
-            # extract the fields from the labels of the base-change curves:
-            pol_to_nf = {tuple(rec["coeffs"]): rec for rec in db.nf_fields.search({"label": {"$in": list(nf_to_curve)}}, ["label", "coeffs", "disc_abs", "disc_sign", "subfields", "subfield_mults"])}
-        else:
-            pol_to_nf = {}
+        # look up all the fields in the growth table in a single query
+        # (the projection must include the columns needed by field_pretty)
+        pol_to_nf = {tuple(rec["coeffs"]): rec for rec in db.nf_fields.search({"$or": [{"coeffs": tgd['field']} for tgd in tgdata]}, ["label", "coeffs", "disc_abs", "disc_sign", "subfields", "subfield_mults"])}
         tg['fields_missing'] = False
 
         for tgd in tgdata:
@@ -908,7 +906,7 @@ class WebEC():
                 tg['fields_missing'] = True
             else:
                 tg1['f'] = formatfield(F, data=nf_data)
-                bcc = nf_to_curve[nf_data["label"]]
+                bcc = nf_to_curve.get(nf_data["label"])
             T = tgd['torsion']
             tg1['t'] = r'\(' + r' \oplus '.join(r'\Z/{}\Z'.format(n) for n in T) + r'\)'
             if bcc:

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -216,7 +216,9 @@ def field_pretty(label, wnf=None):
     Given an LMFDB number field label, returns a "pretty" latexed representation of this field (if it exists)
     Otherwise, simply returns back the label itself if unable to find a latex representation.
 
-    field should be a WebNumberField object, which is constructed if needed if not provided
+    wnf, if provided, should be a WebNumberField for this label; it may have been
+    built from a search projection, and is only used if it has the needed columns
+    (since the result is cached by label alone, it must not depend on the caller)
 
     Cases implemented:
      - Rational field, quadratic fields, pure cubic fields, imprimitive quartic fields,
@@ -240,6 +242,14 @@ def field_pretty(label, wnf=None):
     def _sqrt_symbol(z):
         return 'i' if z == -1 else r'\sqrt{%d}' % z
 
+    # A caller-supplied wnf may come from a projection lacking the columns a
+    # case below needs (e.g. the reflex fields table passes only the label);
+    # reload from the database unless every needed column is present
+    def _wnf_with(*keys):
+        if wnf is None or wnf._data is None or any(k not in wnf._data for k in keys):
+            return WebNumberField(label)
+        return wnf
+
     # Case 2: Quadratic fields Q(\sqrt{D})
     # (note that we give the pretty name for 2.0.4.1 as \Q(\sqrt{-1}), and not \Q(i))
     if d == '2':
@@ -261,8 +271,7 @@ def field_pretty(label, wnf=None):
 
     # Case 5: Imprimitive quartic fields
     if d == '4':
-        if wnf is None:
-            wnf = WebNumberField(label)
+        wnf = _wnf_with('subfields', 'subfield_mults', 'coeffs')
         subs = wnf.subfields()
 
         # Case 5a: Biquadratic fields Q(\sqrt{A}, \sqrt{B})
@@ -311,8 +320,7 @@ def field_pretty(label, wnf=None):
 
     # Case 6: Pure cubic fields Q(\sqrt[3]{N})
     if d == '3':
-        if wnf is None:
-            wnf = WebNumberField(label)
+        wnf = _wnf_with('disc_abs', 'disc_sign', 'coeffs')
         # Check that discriminant is negative
         if wnf.disc() < 0:
             # Explicitly solve for a real root of defining polynomial (using Cardano's formula):
@@ -339,8 +347,7 @@ def field_pretty(label, wnf=None):
     # Case 7: General multi-quadratic fields: Q(\sqrt{D_1}, ..., \sqrt{D_k})
     if ZZ(d).is_power_of(2):
         k = ZZ(d).valuation(2)
-        if wnf is None:
-            wnf = WebNumberField(label)
+        wnf = _wnf_with('subfields', 'subfield_mults')
         all_subs = wnf.subfields()
         quad_subs = [s[0] for s in all_subs if s[0].count(',') == 2]
         num_quad_subs = len(quad_subs)


### PR DESCRIPTION
…isplay

field_pretty is cached by label alone, but the reflex fields table on CM number field pages passes a WebNumberField shell containing only the label; using it made field_pretty silently return the raw label and poison the cache entry used for the page title (the test_pretty_labels CI failure). Reload from the database unless the supplied wnf has every column the case at hand needs.

Also look up all torsion growth fields (not just those with base change curves) in a single query, so fields present in the database are linked rather than displayed as missing.