### PR TITLE
Add fifth option in Malle status SelectBox

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -642,7 +642,8 @@ class GalSearchArray(SearchArray):
                      ("0", "b_M = b_W = b_T"),
                      ("1", "b_M < b_W = b_T"),
                      ("2", "b_M = b_W < b_T"),
-                     ("3", "b_M < b_W < b_T")],
+                     ("3", "b_M < b_W < b_T"),
+                     ("4", "b_M < b_T, b_W unknown")],
             example_col=True,
             advanced=True)
 


### PR DESCRIPTION
This just adds a fifth option in the Malle status SelectBox, which searches for Galois groups where Malle's $b_M$-constant and Turkelli's $b_T$-constant are known, but Wang's $b_W$-constant is still unknown (this was suggested at the LMFDB Malle workshop at ICERM).